### PR TITLE
Fix failure with newly strict extname call

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -77,6 +77,8 @@ var prototype = {
 
 exports.create = function (file) {
 
+    file = file || '';
+
     return Object.create(prototype, {
         _data: {
             enumerable: false,


### PR DESCRIPTION
io.js introduces a stricter extname call, and we were passing undefined
to it. This leaves our complete lack of error handling intact, but gives
the same result it did previously.
