### PR TITLE
Update bundle.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,9 +29,8 @@ exports.createReadStream = function (options) {
     options = options || {};
 
     assert.ok(options.src, 'No input file specified.');
-    assert.ok(options.props, 'No properties file specified.');
 
-    handle = handler.create(maybeAddMetadata(bundle.create(options.props), options.enableMetadata));
+    handle = handler.create(maybeAddMetadata(bundle.create(options.props, options.src), options.enableMetadata));
     src = fs.createReadStream(options.src);
     dest = tagfinder.createParseStream(handle);
 

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -52,10 +52,16 @@ var prototype = {
     },
 
     load: function (callback) {
+
         var that = this;
 
         if (this._data) {
             callback(null, this);
+            return;
+        }
+
+        if (!this.name) {
+            callback(new Error('Content missing for ' + this.src));
             return;
         }
 
@@ -84,7 +90,7 @@ var prototype = {
 };
 
 
-exports.create = function (file) {
+exports.create = function (file, src) {
 
     file = file || '';
 
@@ -111,6 +117,13 @@ exports.create = function (file) {
             enumerable: true,
             writable: false,
             value: path.basename(file, path.extname(file))
+        },
+
+        // the name of the template file requiring the content
+        src: {
+            enumerable: true,
+            writable: false,
+            value: src || 'template'
         }
     });
 };

--- a/test/bundle.js
+++ b/test/bundle.js
@@ -68,15 +68,21 @@ test('bundle', function (t) {
         });
     });
 
-
-    t.test('load err - no file', function (t) {
-        bundle.create('').load(function (err, bun) {
-            t.ok(err);
+    t.test('load err - no file (w/src)', function (t) {
+        bundle.create('', 'parentFile.dust').load(function (err, bun) {
+            t.equal(err.message, 'Content missing for parentFile.dust');
             t.notOk(bun);
             t.end();
         });
     });
 
+    t.test('load err - no file (w/o src)', function (t) {
+        bundle.create('').load(function (err, bun) {
+            t.equal(err.message, 'Content missing for template');
+            t.notOk(bun);
+            t.end();
+        });
+    });
 
     t.test('get', function (t) {
         var file = path.join(__dirname, 'fixtures', 'content', 'index.properties');
@@ -127,7 +133,6 @@ test('bundle', function (t) {
             t.end();
         });
     });
-
 
     t.test('get nothing', function (t) {
         var file = path.join(__dirname, 'fixtures', 'content', 'index.properties');

--- a/test/index.js
+++ b/test/index.js
@@ -41,22 +41,6 @@ test('localizr', function (t) {
     });
 
 
-    t.test('invalid props', function (t) {
-        var options;
-
-        options = {
-            src: path.join(__dirname, 'fixtures', 'templates', 'index.dust'),
-            props: undefined
-        };
-
-        t.throws(function () {
-            localizr.createReadStream(options);
-        });
-
-        t.end();
-    });
-
-
     t.test('invalid options', function (t) {
         t.throws(function () {
             localizr.createReadStream();


### PR DESCRIPTION
Add support for preserving the file that referenced the partial, so that we can complain when the content does not exit.
